### PR TITLE
Fix(user): Fix user deletion

### DIFF
--- a/src/routes/restricted/user/+page.server.js
+++ b/src/routes/restricted/user/+page.server.js
@@ -371,6 +371,16 @@ export const actions = {
     const data = await request.formData();
     const login = data.get("login")?.toString();
     if (!login) return { failure: "no login provided" };
+
+    const user = await prisma.user.findFirst({
+      where: { login },
+      select: { id: true },
+    });
+    if (!user) return { failure: "user not found" };
+
+    await prisma.session.deleteMany({
+      where: { user_id: user.id },
+    });
     await prisma.user.delete({ where: { login } });
     return { success: true };
   },


### PR DESCRIPTION
This commit fixes a bug that caused a 500 internal server error when deleting a user. The error was caused by not deleting the user's sessions before deleting the user, which violated a foreign key constraint in the database.

The `delete_user` action in `src/routes/restricted/user/+page.server.js` has been updated to first retrieve the user's ID, then delete all associated sessions, and finally delete the user.

I have run the development server, but I was unable to test the changes directly. Please verify that the fix works as expected.