### PR TITLE
Refactor(user): Remove admin controls from UserCard

### DIFF
--- a/src/lib/components/UserCard.svelte
+++ b/src/lib/components/UserCard.svelte
@@ -44,32 +44,6 @@
 					<p>{user.travails}</p>
 				</div>
 			</div>
-			{#if $page.data.user?.admin}
-				<div class="profile-card admin-controls">
-					<h4>Admin Controls</h4>
-					<h5>Autres (Lecture seule)</h5>
-					<p>id: {user.id}</p>
-					<p>login: {user.login}</p>
-					<p>admin privileges: {user.admin}</p>
-					<p>date création: {user.createdAt}</p>
-					<p>derniere mise a jour: {user.updatedAt}</p>
-					<h5>Visibilité</h5>
-					<p>TODO</p>
-					<h5>Admin actions</h5>
-					<form method="POST" action="/restricted/user?/set_admin" use:enhance>
-						<input type="hidden" name="login" value={user.login} />
-						<button type="submit">Give admin permissions</button>
-					</form>
-					<form method="POST" action="/restricted/user?/unset_admin" use:enhance>
-						<input type="hidden" name="login" value={user.login} />
-						<button type="submit">Remove admin permissions</button>
-					</form>
-					<form method="POST" action="/restricted/user?/delete_user" use:enhance>
-						<input type="hidden" name="login" value={user.login} />
-						<button type="submit">Delete this user</button>
-					</form>
-				</div>
-			{/if}
 		</div>
 	</UserProfileModal>
 {/if}


### PR DESCRIPTION
This commit refactors the `UserCard.svelte` component to remove the admin controls from the user modal. The admin controls are now only visible on the main user management page, accessible to admins.

This change was made to simplify the UI and to ensure that admin actions can only be performed from the designated admin section.

I have run the development server, but I was unable to test the changes directly. Please verify that the fix works as expected.